### PR TITLE
Travis and package update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 sudo: false
 language: node_js
 node_js :
- - "4.2"
+ - "4.4.2"
 before_install:
  - npm install -g grunt-cli
 script:
  - grunt -v
+

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "dev-null": "^0.1.1",
-    "grunt": "~0.4.5",
+    "grunt": "1.0.1",
     "grunt-cli": "*",
     "grunt-contrib-jshint": "*",
     "grunt-contrib-watch": "*",


### PR DESCRIPTION
  Explicit node 4.4.2 so its closer to our own devel
  Moving grunt to 1.0.1 gets rid of some warnings for old packages

