### PR TITLE
Trailer module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 *~
+doc

--- a/CHANGES
+++ b/CHANGES
@@ -12,7 +12,7 @@ release 0.0.1
       should have X-Remote-User header set), so this server
       should be run behind a reverse proxy that will perform
       authentication and set the header,
-    'data_truncated' trailer header is set to 'true' if the data
+    'data_truncated' trailer header is set to 'false' if the data
       processing pipeline completed successfully, in case of an
-      error in the pipeline it is set to 'false'. 
+      error in the pipeline it is set to 'true'. 
     

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -5,7 +5,7 @@ module.exports = function(grunt) {
   grunt.initConfig({
 
     jsdoc: {
-      src: ['lib/*.js'],
+      src: ['lib/**/*.js'],
       options: {
         destination: 'doc'
       }
@@ -18,8 +18,8 @@ module.exports = function(grunt) {
     },
 
     jscs: {
-      main: [ 'bin/server.js',
-              'lib/*.js'
+      main: [ 'bin/*.js',
+              'lib/**/*.js'
       ],
       options: {
         config: '.jscsrc'
@@ -29,8 +29,8 @@ module.exports = function(grunt) {
     jshint: {
       all: [
         'Gruntfile.js',
-        'bin/server.js',
-        'lib/*.js'
+        'bin/*.js',
+        'lib/**/*.js'
       ],
       options: {
         jshintrc: '.jshintrc'
@@ -38,35 +38,35 @@ module.exports = function(grunt) {
     },
 
     jasmine_nodejs: {
-      // task specific (default) options 
+      // task specific (default) options
       options: {
         specNameSuffix: "spec.js", // also accepts an array
         helperNameSuffix: "helper.js",
         useHelpers: false,
         random: false,
-        seed: null, 
-        defaultTimeout: 5000, 
+        seed: null,
+        defaultTimeout: 5000,
         stopOnFailure: false,
         traceFatal: 2,
-        // configure one or more built-in reporters 
+        // configure one or more built-in reporters
         reporters: {
           console: {
-            colors: true,        // (0|false)|(1|true)|2 
-            cleanStack: 0,       // (0|false)|(1|true)|2|3 
-            verbosity: 4,        // (0|false)|1|2|3|(4|true) 
-            listStyle: "indent", // "flat"|"indent" 
+            colors: true,        // (0|false)|(1|true)|2
+            cleanStack: 0,       // (0|false)|(1|true)|2|3
+            verbosity: 4,        // (0|false)|1|2|3|(4|true)
+            listStyle: "indent", // "flat"|"indent"
             activity: false
           },
         },
-        // add custom Jasmine reporter(s) 
+        // add custom Jasmine reporter(s)
         customReporters: []
       },
       'server_tests': {
-        // target specific options 
+        // target specific options
         //options: {
         //    useHelpers: true
         //},
-        // spec files 
+        // spec files
         specs: [
           "test/**"
         ]

--- a/bin/client.js
+++ b/bin/client.js
@@ -13,7 +13,7 @@ http.get(
     socketPath: '/tmp/' + user + '/npg_ranger.sock',
     path: '/sample?region=1:77970-77980&accession=ERS1060068&format=sam',
     headers: {'X-Remote-User': user}
-  }, 
+  },
   function(response) {
     // Continuously update stream with data
     var body = '';

--- a/lib/http/trailer.js
+++ b/lib/http/trailer.js
@@ -43,10 +43,10 @@ exports.declare = (response) => {
  * @param response  - HTTP response object
  * @param truncated - boolean flag indicating whether the data
  *                    are truncated
- */   
+ */
 exports.setDataTruncation = (response, truncated) =>  {
   validateResponse(response);
-  if (typeof(truncated) !== 'boolean' ) {
+  if ( typeof (truncated) !== 'boolean' ) {
     throw new ReferenceError('boolean flag indicating data truncation is required');
   }
   let trailers = response.getHeader(TRAILER_HEADER_NAME);

--- a/lib/http/trailer.js
+++ b/lib/http/trailer.js
@@ -1,0 +1,61 @@
+"use strict";
+
+/**
+ * trailer module.
+ * @module lib/http/trailer
+ *
+ * @description Helper module for setting HTTP trailer headers.
+ *
+ * @example <caption>Example usage of the trailer module.</caption>
+ *   const trailer = require('../lib/http/trailer.js');
+ *   // Declare trailers
+ *   trailer.declare(response);
+ *   // Mark the data as truncated
+ *   trailer.setDataTruncation(response);    // Data truncated
+ *   trailer.setDataTruncation(response, 0); // Data truncated
+ *   trailer.setDataTruncation(response, 1); // Data not truncated
+ *
+ * @author Marina Gourtovaia
+ * @copyright Genome Research Limited 2016
+ */
+
+const TRAILER_HEADER_NAME     = 'Trailer';
+const DATA_TRUNCATION_TRAILER = 'data-truncated';
+
+function validateResponse(response) {
+  if (!response) {
+    throw new ReferenceError('HTTP response object is required');
+  }
+}
+
+/**
+ * Declares the names of the trailers. If called after the headers
+ * have been set, an error is raised.
+ * @param response - HTTP response object
+ */
+exports.declare = (response) => {
+  validateResponse(response);
+  response.setHeader(TRAILER_HEADER_NAME, DATA_TRUNCATION_TRAILER);
+};
+
+/**
+ * Sets data truncation trailer to the given value.
+ * @param response  - HTTP response object
+ * @param truncated - boolean flag indicating whether the data
+ *                    are truncated
+ */   
+exports.setDataTruncation = (response, truncated) =>  {
+  validateResponse(response);
+  if (typeof(truncated) !== 'boolean' ) {
+    throw new ReferenceError('boolean flag indicating data truncation is required');
+  }
+  let trailers = response.getHeader(TRAILER_HEADER_NAME);
+  // Check that this trailer has been declared
+  if (trailers && trailers.includes(DATA_TRUNCATION_TRAILER)) {
+    var header = {};
+    header[DATA_TRUNCATION_TRAILER] = truncated.toString();
+    response.addTrailers(header);
+  } else {
+    throw new Error('Cannot set data truncation trailer because it has not been declared');
+  }
+};

--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -50,8 +50,8 @@ const DATA_READY_EVENT_NAME = 'data';
 /** Class mapping client query to the location and access info of sequencing files. */
 class DataMapper extends EventEmitter {
   /**
-   * Creates an DataMapper type object.
-   * @param db - mpngodb connection object
+   * Creates a DataMapper type object.
+   * @param db - mongodb connection object
    */
   constructor(db) {
     super();

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "grunt-cli": "*",
     "grunt-contrib-jshint": "*",
     "grunt-contrib-watch": "*",
-    "grunt-jasmine-nodejs": "^1.5.2",
+    "grunt-jasmine-nodejs": "^1.5.3",
     "grunt-jscs": "*",
     "grunt-jsdoc": "^1.1.0",
     "grunt-jsonlint": "^1.0.7",

--- a/test/http.trailer.spec.js
+++ b/test/http.trailer.spec.js
@@ -1,0 +1,154 @@
+"use strict";
+
+const http    = require('http');
+const fs      = require('fs');
+const tmp     = require('tmp');
+const trailer = require('../lib/http/trailer.js');
+
+describe('Input validation', function() {
+  it('declare - response object is not given - error', function() {
+    expect( () => {trailer.declare()} ).toThrowError(ReferenceError,
+    'HTTP response object is required');
+  });
+  it('setDataTruncation - response object is not given - error', function() {
+    expect( () => {trailer.setDataTruncation()} ).toThrowError(
+    ReferenceError, 'HTTP response object is required');
+  });
+  it('setDataTruncation - response object is not given - error', function() {
+    expect( () => {trailer.setDataTruncation({})} ).toThrowError(
+    ReferenceError, 'boolean flag indicating data truncation is required');
+  });
+  it('setDataTruncation - response object is not given - error', function() {
+    expect( () => {trailer.setDataTruncation({}, 4)} ).toThrowError(
+    ReferenceError, 'boolean flag indicating data truncation is required');
+  });
+});
+
+describe('declare and set a trailer', function() {
+  // Create server HTTP server object.
+  const server = http.createServer();
+  // Generate synchronously a temporary file name.
+  var socket = tmp.tmpNameSync();
+
+  beforeAll(function() {
+    // Start listening on a socket
+    server.listen(socket, () => {
+      console.log(`Server listening on socket ${socket}`);
+    });
+  });
+
+  // This tidy-up callback is not called when the spec exits early
+  // due to an error. Seems to be a bug in jasmine.
+  afterAll(function() {
+    server.close();
+    try { fs.unlinkSync(socket); } catch (e) {}
+  });
+
+  it('Declare and set a trailer to mark data truncation', function(done) {
+
+    server.removeAllListeners('request');
+    server.on('request', (request, response) => {
+      trailer.declare(response);
+      expect(response.getHeader('Trailer')).toBe('data-truncated');
+      response.write('useful payload');
+      trailer.setDataTruncation(response, true);
+      response.end();
+    });
+
+    http.get({socketPath: socket}, function(response) {
+      response.on('data', function() {
+        // not interested in data, but the end event is not called
+        // unless the data is processed
+      });
+      response.on('end', function() {
+        expect(response.rawTrailers).toEqual([ 'data-truncated', 'true' ]);
+        done();
+      });
+    });
+  });
+
+  it('Declare and set a trailer to mark good data', function(done) {
+
+    server.removeAllListeners('request');
+    server.on('request', (request, response) => {
+      trailer.declare(response);
+      expect(response.getHeader('Trailer')).toBe('data-truncated');
+      response.write('useful payload');
+      trailer.setDataTruncation(response, false);
+      response.end();
+    });
+
+    http.get({socketPath: socket}, function(response) {
+      response.on('data', function() {});
+      response.on('end', function() {
+        expect(response.rawTrailers).toEqual([ 'data-truncated', 'false' ]);
+        done();
+      });
+    });
+
+  });
+
+  it('Error setting a trailer that has not been declared', function(done) {
+
+    server.removeAllListeners('request');
+    server.on('request', (request, response) => {
+      response.write('useful payload');
+      expect( () => {trailer.setDataTruncation(response, true)} )
+        .toThrowError(Error,
+        'Cannot set data truncation trailer because it has not been declared');
+      response.end();
+    });
+
+    http.get({socketPath: socket}, function(response) {
+      response.on('data', function() {});
+      response.on('end', function() {
+        expect(response.rawTrailers).toEqual([]);
+        done();
+      });
+    });
+
+  });
+
+  it('If Transfer-Encoding header is not set, the trailer is not set', function(done) {
+
+    server.removeAllListeners('request');
+    server.on('request', (request, response) => {
+      response.removeHeader('Transfer-Encoding');
+      response.setHeader('Content-Type', 'application/json');
+      trailer.declare(response);
+      expect(response.getHeader('Trailer')).toBe('data-truncated');
+      response.write('{"some": "property"}');
+      trailer.setDataTruncation(response, true);
+      response.end();
+    });
+
+    http.get({socketPath: socket}, function(response) {
+      response.on('data', function() {});
+      response.on('end', function() {
+        expect(response.rawTrailers).toEqual([]);
+        done();
+      });
+    });
+
+  });
+
+  it('Trailer cannot be declared after the headers have been sent', function(done) {
+
+    server.removeAllListeners('request');
+    server.on('request', (request, response) => {
+      response.write('payload');
+      expect( () => {trailer.declare(response)} ).toThrowError(Error,
+        "Can't set headers after they are sent.");
+      expect(response.getHeader('Trailer')).toBe(undefined);
+      response.end();
+      done();
+    });
+
+    http.get({socketPath: socket}, function(response) {
+      response.on('data', function() {});
+      response.on('end',  function() {});
+    });
+
+  });
+
+});


### PR DESCRIPTION
This module was cleated as a byproduct of a module for GA4GH-compliant http errors. Tests for this module introduce a way to get hold of, manipulate and pass to routines under test an http response object that is generated internally by the http server and cannot be generated as a stand-alone object.