### PR TITLE
Remove usage of linux-specific command

### DIFF
--- a/test/server/auth.spec.js
+++ b/test/server/auth.spec.js
@@ -118,7 +118,7 @@ describe('Authorisation', function() {
   });
 
   afterAll(() => {
-    child.execSync('pkill mongod');
+    child.execSync(`mongo 'mongodb://localhost:${PORT}/admin' --eval 'db.shutdownServer()'`);
     console.log('\nMONGODB server has been shut down');
     fse.remove(tmp_dir, (err) => {if (err) {console.log(`Error removing ${tmp_dir}: ${err}`);}});
   });

--- a/test/server/auth.spec.js
+++ b/test/server/auth.spec.js
@@ -118,9 +118,8 @@ describe('Authorisation', function() {
   });
 
   afterAll(() => {
-    let out = child.execSync(`mongod --shutdown --dbpath ${tmp_dir} --pidfilepath ${tmp_dir}/mpid`);
-    console.log(`\nMONGODB server has been shut down: ${out}`);
+    child.execSync('pkill mongod');
+    console.log('\nMONGODB server has been shut down');
     fse.remove(tmp_dir, (err) => {if (err) {console.log(`Error removing ${tmp_dir}: ${err}`);}});
   });
 });
-

--- a/test/server/mapper.spec.js
+++ b/test/server/mapper.spec.js
@@ -246,7 +246,7 @@ describe('Data info retrieval', function() {
   });
 
   afterAll(() => {
-    child.execSync('pkill mongod');
+    child.execSync(`mongo 'mongodb://localhost:${PORT}/admin' --eval 'db.shutdownServer()'`);
     console.log('\nMONGODB server has been shut down');
     fse.remove(tmp_dir, (err) => {if (err) {console.log(`Error removing ${tmp_dir}: ${err}`);}});
   });

--- a/test/server/mapper.spec.js
+++ b/test/server/mapper.spec.js
@@ -246,8 +246,8 @@ describe('Data info retrieval', function() {
   });
 
   afterAll(() => {
-    let out = child.execSync(`mongod --shutdown --dbpath ${tmp_dir} --pidfilepath ${tmp_dir}/mpid`);
-    console.log(`\nMONGODB server has been shut down: ${out}`);
+    child.execSync('pkill mongod');
+    console.log('\nMONGODB server has been shut down');
     fse.remove(tmp_dir, (err) => {if (err) {console.log(`Error removing ${tmp_dir}: ${err}`);}});
   });
 });


### PR DESCRIPTION
`mongod --shutdown` is only available on the linux version of mongod, i.e. not OSX, meaning tests were breaking when run on OSX. Changed command to be functionally equivalent but platform agnostic.