### PR TITLE
ensure sockets close to promptly close server

### DIFF
--- a/bin/server.js
+++ b/bin/server.js
@@ -36,14 +36,15 @@ LOGGER.info(config.logOpts());
  */
 
 assert(process.env.USER, 'User environment variable is not defined');
-const server = http.createServer();
+require('http-shutdown').extend();
+const server = http.createServer().withShutdown();
 
 // Exit gracefully on a signal to quit
 process.on('SIGTERM', () => {
-  server.close( () => {process.exit(0);} );
+  server.shutdown( () => {process.exit(0);} );
 });
 process.on('SIGINT', () => {
-  server.close( () => {process.exit(0);} );
+  server.shutdown( () => {process.exit(0);} );
 });
 
 // Connect to the database and, if successful, define

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "node-getopt":  "^0.2.3",
     "config-chain": "1.1.10",
     "commander":    "2.9.0",
-    "js-md5" :      "0.4.1"
+    "js-md5" :      "0.4.1",
+    "http-shutdown": "1.0.3"
   },
   "devDependencies": {
     "dev-null": "^0.1.1",


### PR DESCRIPTION
Making a request to the server using a browser (dalliance or even direct request to server from e.g. firefox) will send header `Connection: keep-alive`, while the ranger client will send `Connection: close`. This means that after request from browser is finished, the socket will stay open and server.close() will not close the server until all sockets have closed. Sockets will only close when browser is closed or node will close socket 2 minutes after last request on socket. This also means that a client that keeps sending new requests on the socket will force the server to stay alive indefinitely.

The http-shutdown module keeps track of sockets and, once the shutdown signal has been sent, will close sockets as they become idle, preventing keep-alive clients holding the server hostage