### PR TITLE
allow for email in the remote user value

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,7 @@
 LIST OF CHANGES for npg_ranger project
 
+  - allow for email in the remote user value
+
   - set node recomended to >= 4.5.0 in package.json
   - add config-chain 1.1.11
   - upgrade moment to 2.15.1 from 2.14.1

--- a/lib/config.js
+++ b/lib/config.js
@@ -45,18 +45,20 @@ const optionsList = [
   ['r','references=PATH'  ,'PATH to dir containing reference repository'],
   ['s','skipauth'         ,'skip authorisation steps'],
   ['' ,'anyorigin'        ,'accept CORS requests from any origin'],
+  ['e','emaildomain'      ,'email domain to validate the remote user value against'],
   ['d','debug'            ,'debugging mode for this server'],
   ['h','help'             ,'display this help']
 ];
 
 const defaultOptions = {
-  config_ro:  false,
-  originlist: null,
-  proxylist:  null,
-  protocol:   DEFAULT_PROTOCOL,
-  hostname:   os.hostname() || 'localhost',
-  mongourl:   'mongodb://localhost:27017/imetacache',
-  timeout:    3,
+  config_ro:   false,
+  originlist:  null,
+  emaildomain: null,
+  proxylist:   null,
+  protocol:    DEFAULT_PROTOCOL,
+  hostname:    os.hostname() || 'localhost',
+  mongourl:    'mongodb://localhost:27017/imetacache',
+  timeout:     3,
   mongoopt: {
     db: {
       numberofRetries: 5
@@ -69,7 +71,7 @@ const defaultOptions = {
       }
     },
     replSet: {},
-    mongos: {}
+    mongos:  {}
   }
 };
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -35,19 +35,19 @@ const DEFAULT_PROTOCOL = 'http:';
 const RO_OPTION_KEY    = 'config_ro';
 
 const optionsList = [
-  ['p','port=PORT'        ,'PORT or socket which server listens on'],
-  ['m','mongourl=URI'     ,'URI to contact mongodb'],
-  ['t','tempdir=PATH'     ,'PATH of temporary directory'],
-  ['H','hostname=HOST'    ,'override hostname with HOST'],
-  ['' ,'multiref'         ,'allow merging files with differing references. disables VCF output'],
-  ['c','configfile=PATH'  ,'PATH of configfile'],
-  ['g','timeout=SECONDS'  ,'SECONDS to wait before killing child processes'],
-  ['r','references=PATH'  ,'PATH to dir containing reference repository'],
-  ['s','skipauth'         ,'skip authorisation steps'],
-  ['' ,'anyorigin'        ,'accept CORS requests from any origin'],
-  ['e','emaildomain'      ,'email domain to validate the remote user value against'],
-  ['d','debug'            ,'debugging mode for this server'],
-  ['h','help'             ,'display this help']
+  ['p','port=PORT'         ,'PORT or socket which server listens on'],
+  ['m','mongourl=URI'      ,'URI to contact mongodb'],
+  ['t','tempdir=PATH'      ,'PATH of temporary directory'],
+  ['H','hostname=HOST'     ,'override hostname with HOST'],
+  ['' ,'multiref'          ,'allow merging files with differing references. disables VCF output'],
+  ['c','configfile=PATH'   ,'PATH of configfile'],
+  ['g','timeout=SECONDS'   ,'SECONDS to wait before killing child processes'],
+  ['r','references=PATH'   ,'PATH to dir containing reference repository'],
+  ['s','skipauth'          ,'skip authorisation steps'],
+  ['' ,'anyorigin'         ,'accept CORS requests from any origin'],
+  ['e','emaildomain=DOMAIN','email domain to validate the remote user value against'],
+  ['d','debug'             ,'debugging mode for this server'],
+  ['h','help'              ,'display this help']
 ];
 
 const defaultOptions = {

--- a/lib/server/auth.js
+++ b/lib/server/auth.js
@@ -8,6 +8,8 @@
  *              Relies on data access group being known for each data
  *              source and the user having access to a whole set or subset
  *              of data access groups.
+ *              If the emaildomain configuration option is set, expects
+ *              the username to be an e-mail for the given domain.
  *
  * @example <caption>Example usage of the auth module.</caption>
  *   const DataAccess = require('../lib/server/auth.js');
@@ -42,8 +44,9 @@
  */
 
 const LOGGER       = require('winston');
-
 const EventEmitter = require('events');
+
+const config       = require('../config.js');
 
 const ACCESS_CONTROL_COLLECTION = 'access_control_group';
 const AUTH_EVENT_NAME           = 'authorised';
@@ -63,6 +66,24 @@ class DataAccess extends EventEmitter {
     this.db    = db;
   }
 
+  _getName(uname) {
+    uname = uname.trim();
+    if (uname) {
+      let domain = config.provide().get('emaildomain');
+      if (domain) {
+        // Allow alphanumerics, _, - and . in a username.
+        // Ensure special characters are properly escaped.
+        let re = new RegExp(
+          '([\\w\\.-]+)@' +
+          domain.replace(/\./g, '\\.')
+          + '$', 'im');
+        let result = uname.match(re);
+        uname = result ? result[1] : null;
+      }
+    }
+    return uname;
+  }
+
   /**
    * Authorise the user and emit an appropriate event.
    * @param username - username as a string
@@ -73,13 +94,21 @@ class DataAccess extends EventEmitter {
     if (!username) {
       throw new ReferenceError('Username is required');
     }
+    let original_username = username;
+    username = this._getName(username);
+    if (!username) {
+      this.emit(AUTH_FAILED_EVENT_NAME, original_username,
+        'Invalid user "' + original_username + '"');
+      return;
+    }
+
     if (!accessGroups || (accessGroups instanceof Array === false) ||
        (accessGroups.length === 0)) {
       throw new Error('Access groups array is not available');
     }
 
     if (!accessGroups.every( (id) => { return id; })) {
-      this.emit(AUTH_FAILED_EVENT_NAME, username,
+      this.emit(AUTH_FAILED_EVENT_NAME, original_username,
         'Some access group ids are not defined');
       return;
     }
@@ -97,13 +126,13 @@ class DataAccess extends EventEmitter {
 
     var countCallback = (err, count) => {
       if (err) {
-        this.emit(AUTH_FAILED_EVENT_NAME, username,
+        this.emit(AUTH_FAILED_EVENT_NAME, original_username,
           'Failed to get authorisation info, DB error: ' + err);
       } else {
         if (count == agroupIds.length) {
-          this.emit(AUTH_EVENT_NAME, username);
+          this.emit(AUTH_EVENT_NAME, original_username);
         } else {
-          this.emit(AUTH_FAILED_EVENT_NAME, username,
+          this.emit(AUTH_FAILED_EVENT_NAME, original_username,
             'Not authorised for ' + (count ? 'some' : 'any') + ' of the files');
         }
       }

--- a/lib/server/controller.js
+++ b/lib/server/controller.js
@@ -174,8 +174,9 @@ class RangerController {
         });
         da.once('failed', (username, message) => {
           da.removeAllListeners();
+          LOGGER.info(message);
           this.errorResponse(this.response, 403,
-            `Authorisation failed for user '${username}': ${message}`);
+            `Authorization failed for user '${username}'`);
         });
         da.authorise(user.username, data.map( (d) => {return d.accessGroup;} ));
       }

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -108,16 +108,18 @@ describe('Creating temp file path', function() {
 
 describe('Listing config options', function() {
   it('Options listing', function() {
-    config.provide( () => {return {mongourl: 'mymongourl',
-                                   hostname: 'myhost',
-                                   tempdir:  '/tmp/mydir',
-                                   port:     9999,
-                                   debug:    true,
-                                   help:     true
+    config.provide( () => {return {mongourl:    'mymongourl',
+                                   hostname:    'myhost',
+                                   tempdir:     '/tmp/mydir',
+                                   port:        9999,
+                                   debug:       true,
+                                   emaildomain: 'some.com',
+                                   help:        true
                                   };} );
     let a = ['anyorigin=undefined',
              'configfile=undefined',
              'debug=true',
+             'emaildomain="some.com"',
              'hostname="myhost"',
              'mongourl="mymongourl"',
              'multiref=undefined',


### PR DESCRIPTION
The X-Remote-User header value is set by the reverse proxy server and can be any type of user identifier, for example, a username or an email address. For the purpose of authorization, we will use this identifier as it is, unless the 'emaildomain' server configuration option is set. In the latter case we will expect the user identifier to be an email address with the domain given by the  'emaildomain' option; for authorization we will use the part of the e-mail address before '@'.