### PR TITLE
Serve files directly

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -11,6 +11,7 @@ release 0.7.0
   - upgrade tmp to 0.0.30 from 0.0.29
   - upgrade fs-extra to 1.0.0 from ^0.30.0
   - upgrade winston to 2.3.0 from 2.2.0
+  - /file url now serves files of all formats without processing
 
 release 0.6.0
   - example apache.conf in docs

--- a/docs/server.rst
+++ b/docs/server.rst
@@ -163,6 +163,30 @@ If installed globally
 EXAMPLES AND COMPATIBLE CLIENTS
 ===============================
 
+available urls
+==============
+
+There are three different url paths recognised by the server:
+
+::
+
+ /file?name=$NAME[&directory=$DIR]
+ /sample?accession=$ACCESSION[&format={BAM,SAM,CRAM,VCF}][&region=$REG]
+ /ga4gh/v.0.1/sample/$ACCESSION[&format={BAM,SAM,CRAM,VCF}][&region=$REG]
+ # $REG is in format <referenceName>:<startLoc>-<endLoc>
+
+Each will provide a response in a different way:
+
+/file will search the database for a file with matching name, then will stream that file to you. This url can only return one file, so if there is more than one file with $NAME, you will be prompted to also provide a directory $DIR. This url supports byte-range serving using the Content-Range header.
+
+/sample will search for content files with given accession, merge them, then stream the file (or specified region) in BAM format (unless overridden).
+
+/ga4gh/v.0.1/sample will provide a json response, mapping the url to a /sample url with the same accession and queries. The npg_ranger client and `our biodalliance fork`__ will automatically follow this redirect, curl and other http clients will not.
+
+.. _Biodall: https://github.com/wtsi-npg/dalliance
+
+__ Biodall_
+
 curl
 ====
 

--- a/lib/server/controller.js
+++ b/lib/server/controller.js
@@ -365,8 +365,8 @@ class RangerController {
     }
   }
 
-  _fileClback(q, p) {
-    if (p !== '/file' || !q.name) {
+  _fileClback(q) {
+    if (!q.name) {
       this.errorResponse(this.response, 422,
         'Invalid request: file name should be given');
     } else {
@@ -375,8 +375,8 @@ class RangerController {
   }
 
 
-  _sampleClback(q, p) {
-    if (p !== '/sample' || !q.accession) {
+  _sampleClback(q) {
+    if (!q.accession) {
       this.errorResponse(this.response, 422,
         'Invalid request: sample accession number should be given');
     } else {

--- a/lib/server/controller.js
+++ b/lib/server/controller.js
@@ -18,6 +18,7 @@
  */
 
 const assert      = require('assert');
+const send        = require('send');
 const url         = require('url');
 const LOGGER      = require('winston');
 const DataAccess  = require('./auth.js');
@@ -28,6 +29,16 @@ const trailer     = require('./http/trailer.js');
 const config      = require('../config.js');
 
 const RANGER_PROXY_URL_KEY = 'rangerProxyURL';
+
+// Define file formats for send module
+
+send.mime.default_type = 'text/plain';
+send.mime.define({
+  'application/vnd.ga4gh.bam': ['bam'],
+  'text/vnd.ga4gh.sam': ['sam'],
+  'application/vnd.ga4gh.cram': ['cram'],
+  'text/vnd.ga4gh.vcf': ['vcf']
+});
 
 /** Application controller */
 class RangerController {
@@ -116,15 +127,34 @@ class RangerController {
     }
   }
 
-  _setupPipeline(query) {
+  _sendData(query) {
     assert(query);
+    assert(query.files.length === 1);
 
+    if (query.files[0].startsWith('irods://')) {
+      // file is on irods, we can't access it so fall back to using
+      // the pipeline (samtools etc.)
+      this._setupPipeline(query);
+      return;
+    }
+
+    this._prepareTrailers();
+    send(this.request, query.files[0]).pipe(this.response);
+  }
+
+  _prepareTrailers() {
     if (this.sendTrailer) {
       trailer.declare(this.response);
     }
+  }
+
+  _setupPipeline(query) {
+    assert(query);
+
+    this._prepareTrailers();
     this.response.setHeader('Content-Type', this.contentType(query.format));
 
-    var endResponse = (truncated) => {
+    let endResponse = (truncated) => {
       if (this.sendTrailer) {
         trailer.setDataTruncation(this.response, truncated);
       }
@@ -187,7 +217,7 @@ class RangerController {
     dm.getFileInfo(query, host);
   }
 
-  _getData(query) {
+  _getData(query, cback) {
     let user = this._user;
     let options = config.provide();
     let host = options.get('hostname');
@@ -201,13 +231,13 @@ class RangerController {
       LOGGER.debug(`Using ref file ${query.reference}`);
       dm.removeAllListeners();
       if (options.get('skipauth')) {
-        this._setupPipeline(query);
+        cback(query);
       } else {
         var da = new DataAccess(this.db);
         da.once('authorised', (username) => {
           da.removeAllListeners();
           LOGGER.debug(`User ${username} is given access`);
-          this._setupPipeline(query);
+          cback(query);
         });
         da.once('failed', (username, message) => {
           da.removeAllListeners();
@@ -329,15 +359,22 @@ class RangerController {
     }
   }
 
-  _directClback(q, p) {
-    if (p === '/file' && !q.name) {
+  _fileClback(q, p) {
+    if (p !== '/file' || !q.name) {
       this.errorResponse(this.response, 422,
         'Invalid request: file name should be given');
-    } else if (p === '/sample' && !q.accession) {
+    } else {
+      this._getData(q, this._sendData.bind(this));
+    }
+  }
+
+
+  _sampleClback(q, p) {
+    if (p !== '/sample' || !q.accession) {
       this.errorResponse(this.response, 422,
         'Invalid request: sample accession number should be given');
     } else {
-      this._getData(q);
+      this._getData(q, this._setupPipeline.bind(this));
     }
   }
 
@@ -490,8 +527,8 @@ class RangerController {
 
     var matchPath = (p) => {
       let map = new Map();
-      map.set(new RegExp(/^\/file$/),   'directClback');
-      map.set(new RegExp(/^\/sample$/), 'directClback');
+      map.set(new RegExp(/^\/file$/),   'fileClback');
+      map.set(new RegExp(/^\/sample$/), 'sampleClback');
       map.set(new RegExp(/^\/ga4gh\/v\.0\.1\/get\/sample\/([\.\w]+)$/), 'redirectClback');
       map.set(new RegExp(/^\/sample\/([\.\w]+)\/reference$/), 'referenceClback');
 

--- a/lib/server/controller.js
+++ b/lib/server/controller.js
@@ -129,8 +129,14 @@ class RangerController {
 
   _sendData(query) {
     assert(query);
-    assert(query.files.length === 1);
+    assert(query.files.length > 0);
 
+    if (query.files.length > 1) {
+      this.errorResponse(this.response, 422,
+        'More than one file exists with this name. ' +
+        'Try also using the \'directory\' query.');
+      return;
+    }
     if (query.files[0].startsWith('irods://')) {
       // file is on irods, we can't access it so fall back to using
       // the pipeline (samtools etc.)

--- a/lib/server/controller.js
+++ b/lib/server/controller.js
@@ -32,7 +32,7 @@ const RANGER_PROXY_URL_KEY = 'rangerProxyURL';
 
 // Define file formats for send module
 
-send.mime.default_type = 'text/plain';
+send.mime.default_type = 'application/octet-stream';
 send.mime.define({
   'application/vnd.ga4gh.bam': ['bam'],
   'text/vnd.ga4gh.sam': ['sam'],
@@ -134,7 +134,7 @@ class RangerController {
     if (query.files.length > 1) {
       this.errorResponse(this.response, 422,
         'More than one file exists with this name. ' +
-        'Try also using the \'directory\' query.');
+        'Add a \'directory\' query parameter, then try again.');
       return;
     }
     if (query.files[0].startsWith('irods://')) {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
     "config-chain":  "1.1.11",
     "commander":     "2.9.0",
     "js-md5" :       "0.4.1",
-    "http-shutdown": "1.1.0"
+    "http-shutdown": "1.1.0",
+    "send":          "0.14.1"
   },
   "devDependencies": {
     "decache": "4.1.0",

--- a/test/server/controller_bioinf.spec.js
+++ b/test/server/controller_bioinf.spec.js
@@ -28,10 +28,7 @@ describe('server fetching', () => {
   let socket = tmp.tmpNameSync();
   let expectedMd5s = {
     'single file': {
-      //'SAM' : ['16b3d79daec1da26d98a4e1b63e800b0'],
-      'BAM' : ['16b3d79daec1da26d98a4e1b63e800b0'],
-      //'CRAM': ['16b3d79daec1da26d98a4e1b63e800b0'],
-      //'VCF' : ['832d2abee762681e6f025ca0df1f38ad']
+      'BAM' : ['16b3d79daec1da26d98a4e1b63e800b0']
     },
     'multiple (merged) files': {
       'SAM' : ['79cb05e3fe428da52da346e7d4f6324a', '9b123c8f3a3e8a59584c2193976d1226'],

--- a/test/server/controller_bioinf.spec.js
+++ b/test/server/controller_bioinf.spec.js
@@ -38,7 +38,7 @@ describe('server fetching', () => {
     }
   };
   let testRuns = {
-    'single file':             '/file?name=20818_1%23888.bam&format=',
+    'single file':             '/file?name=20818_1%23888.bam',
     'multiple (merged) files': '/sample?accession=ABC123456&format='
   };
 
@@ -152,10 +152,12 @@ describe('server fetching', () => {
             }
             return matched;
           }
+          let useFormat = testRuns[description].endsWith('format=');
           http.get(
               {
                 socketPath: socket,
-                path: testRuns[description] + format,
+                path: useFormat ? testRuns[description] + format
+                                : testRuns[description],
                 headers: {TE: 'trailers'}
               }, ( res ) => {
 

--- a/test/server/controller_bioinf.spec.js
+++ b/test/server/controller_bioinf.spec.js
@@ -28,10 +28,10 @@ describe('server fetching', () => {
   let socket = tmp.tmpNameSync();
   let expectedMd5s = {
     'single file': {
-      'SAM' : ['16b3d79daec1da26d98a4e1b63e800b0'],
+      //'SAM' : ['16b3d79daec1da26d98a4e1b63e800b0'],
       'BAM' : ['16b3d79daec1da26d98a4e1b63e800b0'],
-      'CRAM': ['16b3d79daec1da26d98a4e1b63e800b0'],
-      'VCF' : ['832d2abee762681e6f025ca0df1f38ad']
+      //'CRAM': ['16b3d79daec1da26d98a4e1b63e800b0'],
+      //'VCF' : ['832d2abee762681e6f025ca0df1f38ad']
     },
     'multiple (merged) files': {
       'SAM' : ['79cb05e3fe428da52da346e7d4f6324a', '9b123c8f3a3e8a59584c2193976d1226'],


### PR DESCRIPTION
Change the /file url to now provide files directly, without passing through samtools etc.
Lose the ability to convert files between formats, gain the ability to serve arbitrary files (not just sam/bam/cram).
Resolves #107.