### PR TITLE
bump npm deps

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,10 @@
 LIST OF CHANGES for npg_ranger project
 
+  - upgrade moment to 2.17.0 from 2.16.0
+  - upgrade mongodb to 2.2.12 from 2.2.11
+  - upgrade pem to 1.9.2 from 1.8.3
+  - upgrade tmp to 0.0.31 from 0.0.30
+
 release 1.0.0
   - show error in log when controller tests fail to cleanup
   - bring back test for unknown server, keep external servers as pending tests

--- a/package.json
+++ b/package.json
@@ -52,9 +52,9 @@
   "main": "./lib/main.js",
   "dependencies": {
     "winston":       "2.3.0",
-    "moment" :       "2.16.0",
+    "moment" :       "2.17.0",
     "fs-extra":      "1.0.0",
-    "mongodb":       "2.2.11",
+    "mongodb":       "2.2.12",
     "node-getopt":   "^0.2.3",
     "config-chain":  "1.1.11",
     "commander":     "2.9.0",
@@ -76,8 +76,8 @@
     "grunt-jsonlint": "^1.0.7",
     "grunt-browserify": "5.0.0",
     "load-grunt-tasks": "3.5.2",
-    "pem":              "1.8.3",
-    "tmp": "0.0.30",
+    "pem":              "1.9.2",
+    "tmp": "0.0.31",
     "browserify": "13.1.1"
   }
 }


### PR DESCRIPTION
 - upgrade moment to 2.17.0 from 2.16.0
 - upgrade mongodb to 2.2.12 from 2.2.11
 - upgrade pem to 1.9.2 from 1.8.3
 - upgrade tmp to 0.0.31 from 0.0.30