### PR TITLE
Don't send db errors in http response

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -226,8 +226,10 @@ class ServerFactory extends EventEmitter {
         LOGGER.error(`Caught exception: ${err}\n`);
         dbClose(db);
         let code = 1;
-        LOGGER.info(`Exiting with code ${code}`);
-        process.exit(code);
+        process.nextTick(function() {
+          LOGGER.info(`Exiting with code ${code}`);
+          process.exit(code);
+        });
       });
 
       // Set up a callback for requests.

--- a/lib/server/controller.js
+++ b/lib/server/controller.js
@@ -198,6 +198,7 @@ class RangerController {
     dm.once('error', ( err ) => {
       dm.removeAllListeners();
       this.errorResponse(this.response, 500, err);
+      throw new Error(err);
     });
     dm.once('nodata', ( message ) => {
       dm.removeAllListeners();

--- a/lib/server/mapper.js
+++ b/lib/server/mapper.js
@@ -210,13 +210,14 @@ class DataMapper extends EventEmitter {
     let refMismatchMessage = `Not all references match for ${defaultMessage}`;
     cursor.each( (err, doc) => {
       if (err) {
+        LOGGER.error('Failed to map input to files, DB error: ' + err);
         try {
           cursor.close();
         } catch (e) {
           LOGGER.warn('Error while trying to close cursor: ' + e);
         }
         this.emit(ERROR_EVENT_NAME,
-          'Failed to map input to files, DB error: ' + err);
+          'Failed to map input to files, DB error');
       } else {
         if (doc != null) {
           files.push(doc);

--- a/lib/server/mapper.js
+++ b/lib/server/mapper.js
@@ -210,7 +210,8 @@ class DataMapper extends EventEmitter {
     let refMismatchMessage = `Not all references match for ${defaultMessage}`;
     cursor.each( (err, doc) => {
       if (err) {
-        LOGGER.error('Failed to map input to files, DB error: ' + err);
+        LOGGER.error('Failed to map input to files, DB error: ' + err +
+                     ' Not attempting to recover; closing server');
         try {
           cursor.close();
         } catch (e) {

--- a/test/server/mapper.spec.js
+++ b/test/server/mapper.spec.js
@@ -92,8 +92,7 @@ describe('Data info retrieval', function() {
         assert.equal(err, null);
         var dm = new DataMapper(db);
         dm.once('data', () => {
-          // Data should not be returned, so fail
-          expect(true).toBe(false);
+          fail();
           done();
         });
         dm.once('nodata', (reason) => {
@@ -109,8 +108,7 @@ describe('Data info retrieval', function() {
         assert.equal(err, null);
         var dm = new DataMapper(db);
         dm.once('data', () => {
-          // No data should be returned, so fail
-          expect(true).toBe(false);
+          fail();
           done();
         });
         dm.once('nodata', (reason) => {


### PR DESCRIPTION
If the mongodb library (cursor.each) shows an error (e.g. not authorised to connect to database), error message is sent as http error message, and the error message is not logged directly (appears in log because server response message is logged, logged at info level and not error).  
We probably don't want to show the error message directly (mongodb's errors are very verbose, e.g. shows the query which failed), so instead log the error message, and send a less verbose http error