### PR TITLE
Updated dependencies in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ addons:
   apt:
     packages:
       - libssl-dev
+      - liblzma-dev
 cache:
   directories:
   - /tmp/htslib
@@ -14,16 +15,20 @@ cache:
   - /tmp/freebayes
 env:
   global:
-    - MONGODB_VERSION=3.2.4
+    - MONGODB_VERSION=3.4.3
     - FREEBAYES_VERSION="v1.1.0"
-    - BIOBAMBAM_VERSION="2.0.50-release-20160705161609"
-    - HTSLIB_VERSION="1.3.2"
-    - SAMTOOLS1_VERSION="1.3.1-npg-Sep2016"
+    - BIOBAMBAM_VERSION="2.0.72-release-20170316102450"
+    - HTSLIB_VERSION="1.4"
+    - SAMTOOLS1_VERSION="1.4"
 before_install:
   - ./.travis/install.sh
   - export PATH="/tmp/usr/bin:${PATH}"
-  - npm install -g npm@3.10.7
-  - npm --version
+  - npm install -g npm@3.10.10
   - npm install -g grunt-cli
+  - npm --version
+  - mongo --version
+  - freebayes --version
+  - bamstreamingmarkduplicates --version
+  - samtools --version
 script:
   - grunt -v

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -20,7 +20,7 @@ popd
 fi
 
 if [ ! "$(ls -A samtools)" ]; then
-git clone --branch "${SAMTOOLS1_VERSION}" --depth 1 https://github.com/wtsi-npg/samtools.git samtools
+git clone --branch "${SAMTOOLS1_VERSION}" --depth 1 https://github.com/samtools/samtools.git samtools
 pushd samtools
 mkdir -p acinclude.m4
 pushd acinclude.m4


### PR DESCRIPTION
Also log 3rd party tools' versions

* MongoDB 3.2.4 -> 3.4.3
* HTSlib 1.3.2 -> 1.4 (requires liblzma-dev from apt)
* SAMtools 1.3.1-npg-Sep2016 -> 1.4 (now clones from samtools/samtools,
    no longer from wtsi-npg/samtools)
* Biobambam 2.0.50 -> 2.0.72
* npm 3.10.7 -> 3.10.10

Remember to clear cache on travis, otherwise new versions won't be built