### PR TITLE
upgrading npm deps

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,17 @@
 LIST OF CHANGES for npg_ranger project
 
+  - upgrade async to 2.4.1 from 2.1.4
+  - upgrade browserify to 14.4.0 from 13.3.0
+  - upgrade fs-extra to 3.0.1 from 2.0.0
+  - upgrade grunt-contrib-clean to 1.1.0 from 1.0.0
+  - upgrade grunt-jasmine-nodejs to 1.6.0 from 1.5.4
+  - upgrade http-shutdown to 1.2.0 from 1.1.0
+  - upgrade moment to 2.18.1 from 2.17.1
+  - upgrade mongodb to 2.2.29 from 2.2.22
+  - upgrade pem to 1.9.7 from 1.9.4
+  - upgrade request to 2.81.0 from 2.79.0
+  - upgrade send to 0.15.3 from 0.14.2
+
 release 1.4.1
   - update database entries in docker for public data
   - update ranger Dockerfile to upgrade ranger docker to

--- a/package.json
+++ b/package.json
@@ -51,35 +51,35 @@
   },
   "main": "./lib/main.js",
   "dependencies": {
-    "async":         "2.1.4",
+    "async":         "2.4.1",
     "winston":       "2.3.1",
-    "moment" :       "2.17.1",
-    "fs-extra":      "2.0.0",
-    "mongodb":       "2.2.22",
+    "moment" :       "2.18.1",
+    "fs-extra":      "3.0.1",
+    "mongodb":       "2.2.29",
     "node-getopt":   "^0.2.3",
     "config-chain":  "1.1.11",
     "commander":     "2.9.0",
     "js-md5" :       "0.4.2",
-    "http-shutdown": "1.1.0",
-    "request":       "2.79.0",
-    "send":          "0.14.2"
+    "http-shutdown": "1.2.0",
+    "request":       "2.81.0",
+    "send":          "0.15.3"
   },
   "devDependencies": {
     "decache": "4.1.0",
     "dev-null": "^0.1.1",
     "grunt": "1.0.1",
     "grunt-cli": "*",
-    "grunt-contrib-clean": "1.0.0",
+    "grunt-contrib-clean": "1.1.0",
     "grunt-contrib-jshint": "*",
     "grunt-contrib-watch": "*",
-    "grunt-jasmine-nodejs": "1.5.4",
+    "grunt-jasmine-nodejs": "1.6.0",
     "grunt-jscs": "3.0.1",
     "grunt-jsdoc": "2.1.0",
     "grunt-jsonlint": "^1.0.7",
     "grunt-browserify": "5.0.0",
     "load-grunt-tasks": "3.5.2",
-    "pem":              "1.9.4",
+    "pem":              "1.9.7",
     "tmp": "0.0.31",
-    "browserify": "13.3.0"
+    "browserify": "14.4.0"
   }
 }


### PR DESCRIPTION
 - upgrade async to 2.4.1 from 2.1.4
 - upgrade browserify to 14.4.0 from 13.3.0
 - upgrade fs-extra to 3.0.1 from 2.0.0
 - upgrade grunt-contrib-clean to 1.1.0 from 1.0.0
 - upgrade grunt-jasmine-nodejs to 1.6.0 from 1.5.4
 - upgrade http-shutdown to 1.2.0 from 1.1.0
 - upgrade moment to 2.18.1 from 2.17.1
 - upgrade mongodb to 2.2.28 from 2.2.22
 - upgrade pem to 1.9.7 from 1.9.4
 - upgrade request to 2.81.0 from 2.79.0
 - upgrade send to 0.15.3 from 0.14.2