### PR TITLE
fix premature output stream close when piping

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,9 @@
 LIST OF CHANGES for npg_ranger project
 
+release 1.4.2
+  - fix bug premature end of output stream when piping to output and end of
+    stream in input (response)
+
 release 1.4.1
   - update database entries in docker for public data
   - update ranger Dockerfile to upgrade ranger docker to

--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 LIST OF CHANGES for npg_ranger project
 
 release 1.4.2
+  - fix not showing errors when next process in pipe closes
   - fix bug premature end of output stream when piping to output and end of
     stream in input (response)
 

--- a/bin/client.js
+++ b/bin/client.js
@@ -5,6 +5,8 @@ const assert = require('assert');
 const fs     = require('fs');
 const path   = require('path');
 
+const PassThrough = require('stream').PassThrough;
+
 const cline   = require('commander');
 const async   = require("async");
 const request = require('request');
@@ -31,6 +33,11 @@ const constants     = require('../lib/constants');
  */
 
 /**
+ * @external stream
+ * @see      {@link https://nodejs.org/dist/latest-v4.x/docs/api/stream.html|}
+ */
+
+/**
  * @external async
  * @see      {@link https://www.npmjs.com/package/async|async}
  */
@@ -50,6 +57,7 @@ const constants     = require('../lib/constants');
  *
  * @requires {@link external:fs|fs}
  * @requires {@link external:path|path}
+ * @requires {@link external:stream|stream}
  * @requires {@link external:commander|commander}
  * @requires {@link module:logsetup|logsetup}
  *
@@ -156,14 +164,15 @@ LOGGER.level = cline.loglevel;
 var ca_file = cline.with_ca;
 
 var url = cline.args[0];
-var output;
+var output = new PassThrough();
 if ( cline.args.length === 2 ) {
-  output = fs.createWriteStream(cline.args[1], {
+  var fileoutput = fs.createWriteStream(cline.args[1], {
     flags:     'w',
     autoClose: true
   });
+  output.pipe(fileoutput);
 } else {
-  output = process.stdout;
+  output.pipe(process.stdout);
 }
 
 var exitWithError = (message) => {
@@ -251,6 +260,7 @@ var requestWorker = ( task, callback ) => {
 
               q.drain = () => {
                 LOGGER.debug('All items have been processed in internal queue');
+                output.end();
               };
 
               q.pause(); // To prevent run condition adding tasks vs processing queue
@@ -296,7 +306,7 @@ var requestWorker = ( task, callback ) => {
             }
             callback();
           });
-          res.pipe(output);
+          res.pipe(output, { end: false });
         }
       } else {
         let code = res.statusCode;

--- a/bin/client.js
+++ b/bin/client.js
@@ -197,6 +197,10 @@ if ( token_config ) {
 }
 
 output.on('error', ( err ) => {
+  if (err.code == "EPIPE") {
+    // next process in the pipe closed e.g. samtools printing only headers
+    process.exit(0);
+  }
   exitWithError( err );
 });
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "npg_ranger",
   "title": "npg_ranger",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Streaming service for bioinformatics data.",
   "homepage": "https://github.com/wtsi-npg/npg_ranger",
   "license": "SEE LICENSE IN LICENSE",


### PR DESCRIPTION
explicitly prevent the pipe to end output stream
use a PassThrough to wrap output stream
  where output stream internally will be a file or stdout
prepare release 1.4.2